### PR TITLE
Add support to set WorkDir of Command

### DIFF
--- a/shell_test.go
+++ b/shell_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 )
@@ -119,5 +120,29 @@ func TestCmdOutputFn(t *testing.T) {
 	}
 	if out != "foobar" {
 		t.Fatal("output not expected:", out)
+	}
+}
+
+func TestSetWorkDir(t *testing.T) {
+	var (
+		pwd      = os.Getenv("PWD")
+		testPath = Path(pwd, "_goshell_unique")
+	)
+	defer func() {
+		os.RemoveAll(Path(pwd, "testfile"))
+		os.RemoveAll(testPath)
+	}()
+	if err := os.MkdirAll(testPath, os.ModePerm); err != nil {
+		t.Fatal("unexpected error:", err)
+	}
+
+	p := Cmd("touch", "testfile").SetWorkDir(testPath).Run()
+	if p.ExitStatus != 0 {
+		t.Fatal("unexpected error:", p.Error())
+	}
+
+	_, err := os.Stat(testPath, "testfile")
+	if err != nil {
+		t.Errorf("expected touched file to be present in correct working dir but was not")
 	}
 }


### PR DESCRIPTION
Adding support to set `Command.Dir`. 

Usage: 
```
Cmd("touch file").SetWorkDir(Path("/home", whoami)).Run()
// new file exists at /home/`whoami`/file
```

Unsure if you like the use of `os.Getenv` in your tests but wasn't sure of a meaningful way to test without mucking around in someone's filesystem. Tried to ensure change is low-impact and matches style of the repo. This change is also additive and backwards compatible with existing behavior.